### PR TITLE
Add Symfony5 support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -28,7 +28,7 @@ filter:
 build:
     environment:
         php:
-            version: 5.4
+            version: 7.1
             ini:
                 'always_populate_raw_post_data': '-1'
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php" : ">=5.4",
-        "behat/behat" : "^3.0.0"
+        "behat/behat" : "^3.0.0",
+        "symfony/config": "^4.0|^5.0"
     },
     "require-dev": {
         "phpspec/phpspec" : "2.4.0-alpha2"

--- a/src/Bex/Behat/ExtensionDriverLocator/DriverLocator.php
+++ b/src/Bex/Behat/ExtensionDriverLocator/DriverLocator.php
@@ -106,11 +106,10 @@ class DriverLocator
      */
     private function configureDrivers()
     {
-        $tree = new TreeBuilder();
-        $root = $tree->root('drivers');
+        $tree = new TreeBuilder('drivers');
 
         foreach ($this->drivers as $driverKey => $driver) {
-            $driver->configure($root->children()->arrayNode($driverKey));
+            $driver->configure($tree->getRootNode()->children()->arrayNode($driverKey));
         }
 
         return $tree->buildTree();


### PR DESCRIPTION
This PR is needed to add Symfony 5 support, mentioned in https://github.com/elvetemedve/behat-screenshot/issues/50

In Symfony 5 the TreeBuilder usage has changed, I've changed it to be SF4/SF5 compliant. :
https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md#config

The deprecations in code:
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php#L30
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php#L51

Because of the code changes (it's not possible to configure TreeBuilder through constructor on Symfony 3, as there is no constructor - https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php#L21) I've added a minimum requirement for symfony/config.